### PR TITLE
 Separate concrete interpreter class that caches results 

### DIFF
--- a/include/souper/Infer/AbstractInterpreter.h
+++ b/include/souper/Infer/AbstractInterpreter.h
@@ -3,6 +3,9 @@
 
 #include "llvm/Support/KnownBits.h"
 
+#include "souper/Inst/Inst.h"
+#include "souper/Infer/Interpreter.h"
+
 namespace souper {
   namespace BinaryTransferFunctionsKB {
     llvm::KnownBits add(const llvm::KnownBits &lhs, const llvm::KnownBits &rhs);
@@ -25,6 +28,27 @@ namespace souper {
     llvm::KnownBits ule(const llvm::KnownBits &lhs, const llvm::KnownBits &rhs);
     llvm::KnownBits sle(const llvm::KnownBits &lhs, const llvm::KnownBits &rhs);
   }
+
+  std::string knownBitsString(llvm::KnownBits KB);
+
+  bool isConcrete(souper::Inst *I,
+		  bool ConsiderConsts = true,
+		  bool ConsiderHoles = true);
+
+  llvm::KnownBits findKnownBits(Inst* I,
+				ValueCache& C,
+				bool PartialEval = true);
+  llvm::KnownBits findKnownBitsUsingSolver(Inst *I,
+					   Solver *S,
+					   std::vector<InstMapping> &PCs);
+
+  llvm::ConstantRange findConstantRange(souper::Inst* I,
+					souper::ValueCache& C,
+					bool PartialEval = true);
+  llvm::ConstantRange findConstantRangeUsingSolver(souper::Inst* I,
+						   Solver *S,
+						   std::vector<InstMapping> &PCs);
+
 }
 
 #endif

--- a/include/souper/Infer/AbstractInterpreter.h
+++ b/include/souper/Infer/AbstractInterpreter.h
@@ -36,14 +36,14 @@ namespace souper {
 		  bool ConsiderHoles = true);
 
   llvm::KnownBits findKnownBits(Inst* I,
-				ValueCache& C,
+				ConcreteInterpreter& CI,
 				bool PartialEval = true);
   llvm::KnownBits findKnownBitsUsingSolver(Inst *I,
 					   Solver *S,
 					   std::vector<InstMapping> &PCs);
 
   llvm::ConstantRange findConstantRange(souper::Inst* I,
-					souper::ValueCache& C,
+					ConcreteInterpreter& CI,
 					bool PartialEval = true);
   llvm::ConstantRange findConstantRangeUsingSolver(souper::Inst* I,
 						   Solver *S,

--- a/include/souper/Infer/Interpreter.h
+++ b/include/souper/Infer/Interpreter.h
@@ -66,6 +66,7 @@ struct EvalValue {
     }
   }
 };
+
 using ValueCache = std::unordered_map<souper::Inst *, EvalValue>;
 
 EvalValue evaluateAddNSW(llvm::APInt a, llvm::APInt b);
@@ -80,7 +81,24 @@ EvalValue evaluateShl(llvm::APInt a, llvm::APInt b);
 EvalValue evaluateLShr(llvm::APInt a, llvm::APInt b);
 EvalValue evaluateAShr(llvm::APInt a, llvm::APInt b);
 
-EvalValue evaluateInst(Inst* Root, ValueCache &Cache);
+  class ConcreteInterpreter {
+    ValueCache _Cache;
+    bool _CacheWritable = false;
+
+    EvalValue evaluateSingleInst(Inst* I, std::vector<EvalValue> &Args);
+
+  public:
+    ConcreteInterpreter() {}
+    ConcreteInterpreter(ValueCache &Input) : _Cache(Input) {}
+    ConcreteInterpreter(Inst* I, ValueCache &Input) : _Cache(Input) {
+      _CacheWritable = true;
+      evaluateInst(I);
+      _CacheWritable = false;
+    }
+
+    EvalValue evaluateInst(Inst* Root);
+  };
+
 }
 
 

--- a/include/souper/Infer/Interpreter.h
+++ b/include/souper/Infer/Interpreter.h
@@ -81,15 +81,6 @@ EvalValue evaluateLShr(llvm::APInt a, llvm::APInt b);
 EvalValue evaluateAShr(llvm::APInt a, llvm::APInt b);
 
 EvalValue evaluateInst(Inst* Root, ValueCache &Cache);
-llvm::KnownBits findKnownBits(Inst* I, ValueCache& C, bool PartialEval = true);
-llvm::KnownBits findKnownBitsUsingSolver(Inst *I, Solver *S, std::vector<InstMapping> &PCs);
-llvm::ConstantRange findConstantRange(souper::Inst* I,
-                                      souper::ValueCache& C,
-                                      bool PartialEval = true);
-llvm::ConstantRange findConstantRangeUsingSolver(souper::Inst* I, Solver *S, std::vector<InstMapping> &PCs);
-bool isConcrete(souper::Inst *I, bool ConsiderConsts = true,
-                                 bool ConsiderHoles = true);
-std::string knownBitsString(llvm::KnownBits KB);
 }
 
 

--- a/include/souper/Infer/Pruning.h
+++ b/include/souper/Infer/Pruning.h
@@ -31,7 +31,7 @@ public:
   // not be called when pruning is disabled
 private:
   Inst *LHS;
-  std::vector<EvalValue> LHSValues;
+  std::vector<ConcreteInterpreter> ConcreteInterpreters;
   InstContext &IC;
   SMTLIBSolver *S;
   PruneFunc DataflowPrune;

--- a/include/souper/Inst/Inst.h
+++ b/include/souper/Inst/Inst.h
@@ -277,6 +277,9 @@ Inst *instJoin(Inst *I, Inst *Reserved, Inst *NewInst, InstContext &IC);
 void findVars(Inst *Root, std::vector<Inst *> &Vars);
 
 bool hasGivenInst(Inst *Root, std::function<bool(Inst*)> InstTester);
+bool isReservedConst(Inst *I);
+bool isReservedInst(Inst *I);
+
 void getReservedInsts(Inst *Root, std::vector<Inst *> &ReservedInsts);
 
 void separateBlockPCs(const BlockPCs &BPCs, BlockPCs &BPCsCopy,

--- a/lib/Infer/AbstractInterpreter.cpp
+++ b/lib/Infer/AbstractInterpreter.cpp
@@ -281,18 +281,6 @@ namespace souper {
     }
   }
 
-  bool isReservedConst(Inst *I) {
-    return I->K == Inst::ReservedConst ||
-          (I->K == Inst::Var &&
-          (I->Name.find(ReservedConstPrefix) != std::string::npos));
-  }
-
-  bool isReservedInst(Inst *I) {
-    return I->K == Inst::ReservedInst ||
-          (I->K == Inst::Var &&
-          (I->Name.find(ReservedInstPrefix) != std::string::npos));
-  }
-
   bool isConcrete(Inst *I, bool ConsiderConsts, bool ConsiderHoles) {
     return !hasGivenInst(I, [ConsiderConsts, ConsiderHoles](Inst* instr) {
 			      if (ConsiderConsts && isReservedConst(instr))

--- a/lib/Infer/AbstractInterpreter.cpp
+++ b/lib/Infer/AbstractInterpreter.cpp
@@ -56,6 +56,21 @@ namespace {
 
 namespace souper {
 
+  std::string knownBitsString(llvm::KnownBits KB) {
+    std::string S = "";
+    for (int I = 0; I < KB.getBitWidth(); I++) {
+      if (KB.Zero.isNegative())
+	S += "0";
+      else if (KB.One.isNegative())
+	S += "1";
+      else
+	S += "?";
+      KB.Zero <<= 1;
+      KB.One <<= 1;
+    }
+    return S;
+  }
+
   namespace BinaryTransferFunctionsKB {
     llvm::KnownBits add(const llvm::KnownBits &lhs, const llvm::KnownBits &rhs) {
       return llvm::KnownBits::computeForAddSub(/*Add=*/true, /*NSW=*/false,

--- a/lib/Infer/ExhaustiveSynthesis.cpp
+++ b/lib/Infer/ExhaustiveSynthesis.cpp
@@ -83,6 +83,7 @@ namespace {
 //   or look for feedback from solver, timeouts etc.
 // make sure path conditions work as expected
 // synthesize x.with.overflow
+// synthsize x.saturating
 // remove nop synthesis
 // once an optimization works we can try adding UB qualifiers on the RHS
 //   probably almost as good as synthesizing these directly

--- a/lib/Infer/Interpreter.cpp
+++ b/lib/Infer/Interpreter.cpp
@@ -1,3 +1,17 @@
+// Copyright 2019 The Souper Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "souper/Infer/Interpreter.h"
 
 namespace souper {

--- a/lib/Infer/Pruning.cpp
+++ b/lib/Infer/Pruning.cpp
@@ -1,5 +1,20 @@
+// Copyright 2019 The Souper Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "souper/Infer/Pruning.h"
 #include <cstdlib>
+
 namespace souper {
 
 std::string knownBitsString(llvm::KnownBits KB) {

--- a/lib/Infer/Pruning.cpp
+++ b/lib/Infer/Pruning.cpp
@@ -12,25 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "souper/Infer/AbstractInterpreter.h"
 #include "souper/Infer/Pruning.h"
+
 #include <cstdlib>
 
 namespace souper {
-
-std::string knownBitsString(llvm::KnownBits KB) {
-  std::string S = "";
-  for (int I = 0; I < KB.getBitWidth(); I++) {
-    if (KB.Zero.isNegative())
-      S += "0";
-    else if (KB.One.isNegative())
-      S += "1";
-    else
-      S += "?";
-    KB.Zero <<= 1;
-    KB.One <<= 1;
-  }
-  return S;
-}
 
 std::string getUniqueName() {
   static int counter = 0;

--- a/lib/Inst/Inst.cpp
+++ b/lib/Inst/Inst.cpp
@@ -978,6 +978,18 @@ bool souper::hasGivenInst(Inst *Root, std::function<bool(Inst*)> InstTester) {
   return false;
 }
 
+bool souper::isReservedConst(Inst *I) {
+  return I->K == Inst::ReservedConst ||
+    (I->K == Inst::Var &&
+     (I->Name.find(ReservedConstPrefix) != std::string::npos));
+}
+
+bool souper::isReservedInst(Inst *I) {
+  return I->K == Inst::ReservedInst ||
+    (I->K == Inst::Var &&
+     (I->Name.find(ReservedInstPrefix) != std::string::npos));
+}
+
 Inst *souper::getInstCopy(Inst *I, InstContext &IC,
                           std::map<Inst *, Inst *> &InstCache,
                           std::map<Block *, Block *> &BlockCache,

--- a/tools/souper-interpret.cpp
+++ b/tools/souper-interpret.cpp
@@ -14,6 +14,8 @@
 
 #include "llvm/Support/KnownBits.h"
 #include "llvm/Support/MemoryBuffer.h"
+
+#include "souper/Infer/AbstractInterpreter.h"
 #include "souper/Infer/Interpreter.h"
 #include "souper/Parser/Parser.h"
 #include "souper/Tool/GetSolverFromArgs.h"

--- a/tools/souper-interpret.cpp
+++ b/tools/souper-interpret.cpp
@@ -164,9 +164,19 @@ static int Interpret(const MemoryBufferRef &MB, Solver *S) {
       }
     }
 
+    ConcreteInterpreter CI(InputValues);
+    // Concrete Interpreter
+    if (isConcrete(Rep.Mapping.LHS)) {
+      llvm::outs() << " -------- Concrete Interpreter ----------- \n";
+      CI = ConcreteInterpreter(Rep.Mapping.LHS, InputValues);
+      auto Res = CI.evaluateInst(Rep.Mapping.LHS);
+      Res.print(llvm::outs());
+      llvm::outs() << "\n";
+    }
+
     // Known bits interpreter
     llvm::outs() << "\n -------- KnownBits Interpreter ----------- \n";
-    auto KB = findKnownBits(Rep.Mapping.LHS, InputValues);
+    auto KB = findKnownBits(Rep.Mapping.LHS, CI);
     auto KBSolver = findKnownBitsUsingSolver(Rep.Mapping.LHS, S, InputValuesInstMappings);
     llvm::outs() << "KnownBits result: \n" << knownBitsString(KB) << '\n';
     llvm::outs() << "KnownBits result using solver: \n" << knownBitsString(KBSolver) << "\n\n";
@@ -188,7 +198,7 @@ static int Interpret(const MemoryBufferRef &MB, Solver *S) {
 
     // Constant Ranges interpreter
     llvm::outs() << "\n -------- ConstantRanges Interpreter ----------- \n";
-    auto CR = findConstantRange(Rep.Mapping.LHS, InputValues);
+    auto CR = findConstantRange(Rep.Mapping.LHS, CI);
     auto CRSolver = findConstantRangeUsingSolver(Rep.Mapping.LHS, S, InputValuesInstMappings);
     llvm::outs() << "ConstantRange result: \n" << CR << '\n';
     llvm::outs() << "ConstantRange result using solver: \n" << CRSolver << "\n\n";
@@ -202,12 +212,6 @@ static int Interpret(const MemoryBufferRef &MB, Solver *S) {
     else
       llvm::errs() << "Reults are incomparable.\n";
 
-    if (isConcrete(Rep.Mapping.LHS)) {
-      llvm::outs() << " -------- Concrete Interpreter ----------- \n";
-      auto Res = evaluateInst(Rep.Mapping.LHS, InputValues);
-      Res.print(llvm::outs());
-      llvm::outs() << "\n";
-    }
 
     Index++;
   }

--- a/unittests/Interpreter/InterpreterTests.cpp
+++ b/unittests/Interpreter/InterpreterTests.cpp
@@ -371,25 +371,25 @@ TEST(InterpreterTests, KnownBits) {
 
   Inst *I1 = IC.getConst(llvm::APInt(64, 5));
 
-  souper::ValueCache C;
-  auto KB = souper::findKnownBits(I1, C);
+  souper::ConcreteInterpreter CI;
+  auto KB = souper::findKnownBits(I1, CI);
   ASSERT_EQ(KB.One, 5);
   ASSERT_EQ(KB.Zero, ~5);
 
   Inst *I2 = IC.getInst(Inst::Var, 64, {});
   Inst *I3 = IC.getConst(llvm::APInt(64, 0xFF));
   Inst *I4 = IC.getInst(Inst::And, 64, {I2, I3});
-  KB = souper::findKnownBits(I4, C, /*PartialEval=*/false);
+  KB = souper::findKnownBits(I4, CI, /*PartialEval=*/false);
   ASSERT_EQ(KB.One, 0);
   ASSERT_EQ(KB.Zero, ~0xFF);
 
   Inst *I5 = IC.getInst(Inst::Or, 64, {I2, I1});
-  KB = souper::findKnownBits(I5, C, /*PartialEval=*/false);
+  KB = souper::findKnownBits(I5, CI, /*PartialEval=*/false);
   ASSERT_EQ(KB.One, 5);
   ASSERT_EQ(KB.Zero, 0);
 
   Inst *I6 = IC.getInst(Inst::Shl, 64, {I2, I1});
-  KB = souper::findKnownBits(I6, C, /*PartialEval=*/false);
+  KB = souper::findKnownBits(I6, CI, /*PartialEval=*/false);
   ASSERT_EQ(KB.One, 0);
   ASSERT_EQ(KB.Zero, 31);
 }
@@ -399,20 +399,20 @@ TEST(InterpreterTests, ConstantRange) {
 
   Inst *I1 = IC.getConst(llvm::APInt(64, 5));
 
-  souper::ValueCache C;
-  auto CR = souper::findConstantRange(I1, C, /*PartialEval=*/false);
+  souper::ConcreteInterpreter CI;
+  auto CR = souper::findConstantRange(I1, CI, /*PartialEval=*/false);
   ASSERT_EQ(CR.getLower(), 5);
   ASSERT_EQ(CR.getUpper(), 6);
 
   Inst *I2 = IC.getInst(Inst::Var, 64, {});
   Inst *I3 = IC.getConst(llvm::APInt(64, 0xFF));
   Inst *I4 = IC.getInst(Inst::And, 64, {I2, I3});
-  CR = souper::findConstantRange(I4, C, /*PartialEval=*/false);
+  CR = souper::findConstantRange(I4, CI, /*PartialEval=*/false);
   ASSERT_EQ(CR.getLower(), 0);
   ASSERT_EQ(CR.getUpper(), 0xFF + 1);
 
   Inst *I5 = IC.getInst(Inst::Add, 64, {I4, I1});
-  CR = souper::findConstantRange(I5, C, /*PartialEval=*/false);
+  CR = souper::findConstantRange(I5, CI, /*PartialEval=*/false);
   ASSERT_EQ(CR.getLower(), 5);
   ASSERT_EQ(CR.getUpper(), 0xFF + 5 + 1);
 }


### PR DESCRIPTION
The concrete interpreter only caches results during construction; we
construct a interpreter object with a LHS for each input. The object
(with cached results) is then used for future concrete interpretation in
Abstract interpreters. This should increase performance as all those
RHSes with instruction directly used from LHS have their result already
in cache.