### PR TITLE
add support for generating dot format for souper IR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,7 +205,9 @@ add_library(souperInfer STATIC
 
 set(SOUPER_INST_FILES
   lib/Inst/Inst.cpp
+  lib/Inst/InstGraph.cpp
   include/souper/Inst/Inst.h
+  include/souper/Inst/InstGraph.h
 )
 
 add_library(souperInst STATIC

--- a/include/souper/Inst/InstGraph.h
+++ b/include/souper/Inst/InstGraph.h
@@ -1,0 +1,45 @@
+// Copyright 2019 The Souper Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+#include <set>
+
+#include "souper/Inst/Inst.h"
+
+#include "llvm/Support/raw_ostream.h"
+
+class InstGraph {
+  llvm::raw_ostream &O;
+  souper::Inst* Root;
+  static unsigned graphNum;
+  std::string Name = "Graph";
+  // graph is laid bottom to top
+  std::string Rankdir = "BT";
+  std::set<souper::Inst*> Visited;
+
+  void writeHeader();
+  void writeFooter() { O << "}\n"; }
+
+  void writeNodeProperties(souper::Inst* I);
+  std::string getNodeName(souper::Inst* I);
+  void writeRecursive(souper::Inst* I);
+
+public:
+  InstGraph(llvm::raw_ostream &O, souper::Inst* Root) : O(O), Root(Root) {
+    Name.append(std::to_string(graphNum++));
+  }
+
+  // write the graph to the member variable raw_ostream
+  void write();
+};

--- a/lib/Inst/InstGraph.cpp
+++ b/lib/Inst/InstGraph.cpp
@@ -1,0 +1,93 @@
+// Copyright 2019 The Souper Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vector>
+
+#include "llvm/ADT/StringRef.h"
+
+#include "souper/Inst/Inst.h"
+#include "souper/Inst/InstGraph.h"
+
+unsigned InstGraph::graphNum = 0;
+
+using namespace souper;
+
+void InstGraph::writeNodeProperties(Inst* I) {
+  // properties already written; don't write again.
+  if (Visited.find(I) != Visited.end())
+    return;
+
+  Visited.insert(I);
+
+  if (I == Root) {
+    O << getNodeName(I) << " [style=bold];\n";
+    return;
+  }
+
+  switch(I->K) {
+  case Inst::Kind::ReservedConst:
+  case Inst::Kind::ReservedInst:
+  case Inst::Kind::Var:
+    O << getNodeName(I) << " [shape=box];\n";
+    break;
+  }
+}
+
+std::string InstGraph::getNodeName(Inst* I) {
+  switch(I->K) {
+  case Inst::Kind::Const:
+    return "\"Const " + I->Val.toString(10, true) + "\"";
+  case Inst::Kind::Var:
+    return "\"Var " + I->Name + "\"";
+  case Inst::Kind::ReservedConst:
+  case Inst::Kind::ReservedInst:
+    return "\"Reserved " + I->Name + "\"";
+  default:
+    return "\"" + std::string(Inst::getKindName(I->K)) + "\"";
+  }
+}
+
+void InstGraph::writeRecursive(Inst* I) {
+  if (I->Ops.size() == 0) {
+    return;
+  }
+
+  for (auto &Ops : I->Ops) {
+    writeRecursive(Ops);
+
+    writeNodeProperties(I);
+    writeNodeProperties(Ops);
+
+    O << getNodeName(I);
+    O << " -> ";
+    O << getNodeName(Ops);
+    O << ";\n";
+  }
+}
+
+void InstGraph::writeHeader() {
+  O << "digraph " << Name << " { " << '\n';
+
+  // graph properties
+  O << "rankdir = " << Rankdir << ";\n";
+}
+
+void InstGraph::write() {
+  writeHeader();
+
+  Visited.clear();
+  writeRecursive(Root);
+
+  writeFooter();
+}

--- a/tools/souper-check.cpp
+++ b/tools/souper-check.cpp
@@ -13,8 +13,10 @@
 // limitations under the License.
 
 #include "llvm/Support/MemoryBuffer.h"
+
 #include "souper/Parser/Parser.h"
 #include "souper/Tool/GetSolverFromArgs.h"
+#include "souper/Inst/InstGraph.h"
 
 using namespace llvm;
 using namespace souper;
@@ -70,6 +72,10 @@ int SolveInst(const MemoryBufferRef &MB, Solver *S) {
 
   if (ParseOnly || ParseLHSOnly) {
     llvm::outs() << "; parsing successful\n";
+    // spit out the dot format containing the graph
+    for (auto &Rep : Reps) {
+      InstGraph(llvm::outs(), Rep.Mapping.LHS).write();
+    }
     return 0;
   }
 


### PR DESCRIPTION
./souper-check -parse-lhs-only now also spits out the dot format of the
souper IR which was parsed which can be used to generate PNG like below:

dot -Tpng test.dot > a.png